### PR TITLE
Add test for build

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,0 +1,29 @@
+name: test-build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Clang 17
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 17
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          make install-deps
+
+      - name: Build
+        run: |
+          make debug

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ setup:
 	meson setup --native-file meson.ini build-dbg --buildtype=debug
 
 debug: setup
-	cd build; meson compile
+	cd build-dbg; meson compile
 
 paper:
 	@$(MAKE) -C atc2024
@@ -14,3 +14,8 @@ paper:
 clean:
 	cd build-rel; meson compile --clean
 	cd build-dbg; meson compile --clean
+
+install-deps:
+	sudo apt install -y meson libfmt-dev libaio-dev librados-dev mold \
+    	libgoogle-perftools-dev libtcmalloc-minimal4 libboost-dev \
+    	liburing-dev


### PR DESCRIPTION
- Fixes `make debug` which was pointing to the wrong directory.
- Adds `make install-deps` to automate installing dependencies.
- Adds GitHub Actions test to make sure the above 2 don't break.